### PR TITLE
Fix index page styling so it stays in the middle of the page

### DIFF
--- a/music-journal/components/Layout.js
+++ b/music-journal/components/Layout.js
@@ -1,26 +1,23 @@
 import NavigationBar from './NavigationBar';
+import { Container } from 'react-bootstrap/';
 
 const Layout = ({ children }) => {
   return (
     <>
       {/*<NavigationBar />*/}
-      <div>
+      <Container fluid id="main">
+
         {children}
         <style global jsx>{`
-            html,
-            body,
-            body > div:first-child,
-            div#__next,
-            div#__next > div,
-            div#__next > div > div {
-              height: 100%;    
+            #main {
+              height: 100vh;    
               background: linear-gradient(to bottom, #FFFFFF, #000000);
               margin: 0;
               padding:0;
             }
           `}
         </style>
-      </div>
+      </Container>
     </>
   );
 }


### PR DESCRIPTION
Deals with #6 

I'd think it the future we can make a bunch more changes to the styling

![image](https://user-images.githubusercontent.com/26493662/100294133-ba6c2880-2f7d-11eb-9e09-a0ead46b2163.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jamestwisleton/musicjournal/10)
<!-- Reviewable:end -->
