### PR TITLE
Select song autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,4 @@ Possibly using existing widgets
 ### How authentication works
 
 ![music-journal authentication diagram](images/authentication.png)
+

--- a/README.md
+++ b/README.md
@@ -82,4 +82,3 @@ Possibly using existing widgets
 ### How authentication works
 
 ![music-journal authentication diagram](images/authentication.png)
-

--- a/components/AddMemory.js
+++ b/components/AddMemory.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Row, Col, Form, Button } from 'react-bootstrap/';
 
-const AddMemory = ({ handleSubmit, handleAutocomplete, text, setText, song, setSong }) => {
+const AddMemory = ({ handleSubmit, text, setText, song, setSong }) => {
     return (<>
         <Col xs={12} sm={6}>
             <Row className="justify-content-center" xs={12} >
@@ -16,7 +16,6 @@ const AddMemory = ({ handleSubmit, handleAutocomplete, text, setText, song, setS
                                 as="textarea"
                                 onChange={({ target }) => {
                                     setSong(target.value)
-                                    handleAutocomplete()
                                 }}
                                 rows="1"
                                 value={song}

--- a/components/AddMemory.js
+++ b/components/AddMemory.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Row, Col, Form, Button } from 'react-bootstrap/';
 
-const AddMemory = ({ handleSubmit, text, setText, song, setSong }) => {
+const AddMemory = ({ handleSubmit, handleAutocomplete, text, setText, song, setSong }) => {
     return (<>
         <Col xs={12} sm={6}>
             <Row className="justify-content-center" xs={12} >
@@ -12,10 +12,13 @@ const AddMemory = ({ handleSubmit, text, setText, song, setSong }) => {
                     <Row className="justify-content-center">
                         <Form.Group controlId="formSong">
                             <Form.Label>Write a song name</Form.Label>
-                            <Form.Control 
-                                as="textarea" 
-                                onChange={({target}) => setSong(target.value)} 
-                                rows="1" 
+                            <Form.Control
+                                as="textarea"
+                                onChange={({ target }) => {
+                                    setSong(target.value)
+                                    handleAutocomplete()
+                                }}
+                                rows="1"
                                 value={song}
                             />
                         </Form.Group>
@@ -23,9 +26,9 @@ const AddMemory = ({ handleSubmit, text, setText, song, setSong }) => {
                     <Row>
                         <Form.Group controlId="formText">
                             <Form.Label>Write something about it</Form.Label>
-                            <Form.Control 
-                                as="textarea" 
-                                onChange={({target}) => setText(target.value)} 
+                            <Form.Control
+                                as="textarea"
+                                onChange={({ target }) => setText(target.value)}
                                 rows="3"
                                 value={text}
                             />

--- a/components/Memory.js
+++ b/components/Memory.js
@@ -4,7 +4,7 @@ import AddMemory from '../components/AddMemory'
 import ListMemories from '../components/ListMemories'
 import Suggestions from '../components/Suggestions'
 import { addMemory, getMemories, searchSpotifyTracks } from '../utils/fetcher';
-import {  Row } from 'react-bootstrap/';
+import { Row } from 'react-bootstrap/';
 const Memory = (props) => {
     const [memories, setMemories] = useState()
     const [text, setText] = useState('')
@@ -33,11 +33,12 @@ const Memory = (props) => {
         }
     }
 
-    const handleAutocomplete = async () => {
-        if (song.length > 2) {
-            setSearchResults(await searchSpotifyTracks(song, 5, props.token))
+    useEffect(async () => {
+        if (song > 2) {
+            const response = await searchSpotifyTracks(song, 5, props.token)
+            setSearchResults(response)
         }
-    }
+    }, [song])
 
     return (<>
         <Row>
@@ -48,7 +49,7 @@ const Memory = (props) => {
                 setText={setText}
                 song={song}
                 setSong={setSong}
-                handleAutocomplete={handleAutocomplete} />
+            />
             <Suggestions searchResults={searchResults} />
         </Row>
         <ListMemories memories={memories} />

--- a/components/Memory.js
+++ b/components/Memory.js
@@ -2,12 +2,14 @@ import React, { useEffect, useState } from 'react';
 import withAuth from '../utils/withAuth';
 import AddMemory from '../components/AddMemory'
 import ListMemories from '../components/ListMemories'
-import { addMemory, getMemories } from '../utils/fetcher';
-
+import Suggestions from '../components/Suggestions'
+import { addMemory, getMemories, searchSpotifyTracks } from '../utils/fetcher';
+import {  Row } from 'react-bootstrap/';
 const Memory = (props) => {
     const [memories, setMemories] = useState()
     const [text, setText] = useState('')
     const [song, setSong] = useState('')
+    const [searchResults, setSearchResults] = useState('')
 
     useEffect(async () => {
         try {
@@ -31,15 +33,24 @@ const Memory = (props) => {
         }
     }
 
+    const handleAutocomplete = async () => {
+        if (song.length > 2) {
+            setSearchResults(await searchSpotifyTracks(song, 5, props.token))
+        }
+    }
+
     return (<>
-        <AddMemory
-            {...props}
-            handleSubmit={handleSubmit}
-            text={text}
-            setText={setText}
-            song={song}
-            setSong={setSong}
-        />
+        <Row>
+            <AddMemory
+                {...props}
+                handleSubmit={handleSubmit}
+                text={text}
+                setText={setText}
+                song={song}
+                setSong={setSong}
+                handleAutocomplete={handleAutocomplete} />
+            <Suggestions searchResults={searchResults} />
+        </Row>
         <ListMemories memories={memories} />
     </>
     )

--- a/components/Memory.js
+++ b/components/Memory.js
@@ -11,33 +11,47 @@ const Memory = (props) => {
     const [song, setSong] = useState('')
     const [searchResults, setSearchResults] = useState('')
 
-    useEffect(async () => {
-        try {
-            const response = await getMemories(props.token)
-            setMemories(response)
-        } catch (error) {
-            console.log(error)
+    useEffect(() => {
+        const fetchMemories = async () => {
+            try {
+                const response = await getMemories(props.token)
+                setMemories(response)
+            } catch (error) {
+                console.log(error)
+            }
         }
+        fetchMemories()
+
     }, []);
 
     const handleSubmit = async (event) => {
         event.preventDefault()
-
-        try {
-            const newMemory = await addMemory({ song, text }, props.token)
-            setSong('')
-            setText('')
-            setMemories({ ...memories, ...newMemory })
-        } catch (error) {
-            console.log('handle submit error', error)
+        const submitMemory = async () => {
+            try {
+                const newMemory = await addMemory({ song, text }, props.token)
+                setSong('')
+                setText('')
+                setMemories({ ...memories, ...newMemory })
+            } catch (error) {
+                console.log('handle submit error', error)
+            }
         }
+        submitMemory()
+
     }
 
-    useEffect(async () => {
-        if (song > 2) {
-            const response = await searchSpotifyTracks(song, 5, props.token)
-            setSearchResults(response)
+    useEffect(() => {
+        const searchSpotify = async () => {
+            if (song.length > 2) {
+                try {
+                    const response = await searchSpotifyTracks(song, 5, props.token)
+                    setSearchResults(response)
+                } catch (error) {
+                    console.log(error)
+                }
+            }
         }
+        searchSpotify()
     }, [song])
 
     return (<>

--- a/components/Suggestions.js
+++ b/components/Suggestions.js
@@ -2,12 +2,12 @@ import React from 'react';
 import { Row, Col, Table } from 'react-bootstrap/';
 
 
-const ListMemories = ({ searchResults }) => {
+const ListMemories = ( {searchResults } ) => {
   if (!searchResults || searchResults.length < 1) {
     return <p id="nomemories">Start typing a song to see suggestions!</p>
   }
-
   console.log(searchResults);
+
   return (
     <>
       <Col xs={6}>

--- a/components/Suggestions.js
+++ b/components/Suggestions.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Row, Col, Table } from 'react-bootstrap/';
+
+
+const ListMemories = ({ searchResults }) => {
+  if (!searchResults || searchResults.length < 1) {
+    return <p id="nomemories">Start typing a song to see suggestions!</p>
+  }
+
+  console.log(searchResults);
+  return (
+    <>
+      <Col xs={6}>
+        <Row className="justify-content-center" xs={12} >
+          <h4>Suggested songs</h4>
+        </Row>
+        <Row className="justify-content-center">
+          <Table striped bordered hover size="sm" id="searchresultstable">
+            <thead>
+              <tr>
+                <th>Song</th>
+              </tr>
+            </thead>
+            <tbody id="searchresultstablebody">
+              {searchResults && Object.values(searchResults).map((song) =>
+                <tr key={song}>
+                  <td>{song.trackName}</td>
+                </tr>
+              )}
+            </tbody>
+          </Table>
+        </Row>
+      </Col>
+    </>
+  )
+}
+
+export default ListMemories;

--- a/music-journal/pages/api/search-spotify-tracks.js
+++ b/music-journal/pages/api/search-spotify-tracks.js
@@ -1,0 +1,44 @@
+import { auth } from 'firebase';
+import Cors from 'cors';
+import { database } from '../../utils/initFirebaseAdmin';
+import initMiddleware from '../../utils/initMiddleware'
+import Spotify from '../../utils/initSpotify';
+import verifyToken from '../../utils/verifyToken';
+
+const cors = initMiddleware(
+    Cors({
+        methods: ['GET', 'POST', 'OPTIONS', 'HEAD'],
+    })
+)
+
+const verifyTokenMiddleware = initMiddleware(verifyToken);
+
+async function handler(req, res) {
+    await cors(req, res)
+    await verifyTokenMiddleware(req, res)
+
+    try {
+        const user = auth().currentUser;
+        const ref = await database.ref(`/spotifyAccessToken/${user.uid}`);
+        const snapshot = await ref.orderByValue().once("value")
+        const spotifyToken = await snapshot.val()
+
+        Spotify.setAccessToken(spotifyToken);
+        const data = await Spotify.search(req.query.search, ['track'], { limit: req.query.limit })
+
+        // sure we can consolidate these types of operations to a parameterised function
+        const searchResults = data.body.tracks.items.map((track, idx) => ({
+            position: idx,
+            trackName: track.name,
+            description: `${track.name} by ${track.artists[0].name}`,
+            image: track.album.images[0],
+            track
+        }));
+        res.send(searchResults);
+    } catch (error) {
+        console.log(error);
+        return res.writeHead(401).end();
+    }
+}
+
+export default handler

--- a/pages/api/search-spotify-tracks.js
+++ b/pages/api/search-spotify-tracks.js
@@ -1,0 +1,44 @@
+import { auth } from 'firebase';
+import Cors from 'cors';
+import { database } from '../../utils/initFirebaseAdmin';
+import initMiddleware from '../../utils/initMiddleware'
+import Spotify from '../../utils/initSpotify';
+import verifyToken from '../../utils/verifyToken';
+
+const cors = initMiddleware(
+    Cors({
+        methods: ['GET', 'POST', 'OPTIONS', 'HEAD'],
+    })
+)
+
+const verifyTokenMiddleware = initMiddleware(verifyToken);
+
+async function handler(req, res) {
+    await cors(req, res)
+    await verifyTokenMiddleware(req, res)
+
+    try {
+        const user = auth().currentUser;
+        const ref = await database.ref(`/spotifyAccessToken/${user.uid}`);
+        const snapshot = await ref.orderByValue().once("value")
+        const spotifyToken = await snapshot.val()
+
+        Spotify.setAccessToken(spotifyToken);
+        const data = await Spotify.search(req.query.search, ['track'], { limit: req.query.limit })
+
+        // sure we can consolidate these types of operations to a parameterised function
+        const searchResults = data.body.tracks.items.map((track, idx) => ({
+            position: idx,
+            trackName: track.name,
+            description: `${track.name} by ${track.artists[0].name}`,
+            image: track.album.images[0],
+            track
+        }));
+        res.send(searchResults);
+    } catch (error) {
+        console.log(error);
+        return res.writeHead(401).end();
+    }
+}
+
+export default handler

--- a/utils/fetcher.js
+++ b/utils/fetcher.js
@@ -33,7 +33,7 @@ const getTopTracks = async (token) => {
     const config = {
         headers: { Authorization: `Bearer ${token}` }
     }
-    
+
     const response = await axios.get('/api/top-tracks-from-spotify', config);
     return response.data
 }

--- a/utils/fetcher.js
+++ b/utils/fetcher.js
@@ -24,7 +24,7 @@ const addMemory = async (memory, token) => {
     const config = {
         headers: { Authorization: `Bearer ${token}` }
     }
-    
+
     const response = await axios.post('/api/save-memory', memory, config);
     return response.data
 }
@@ -38,9 +38,9 @@ const getTopTracks = async (token) => {
     return response.data
 }
 
-export { 
-    fetcher, 
-    getMemories, 
+export {
+    fetcher,
+    getMemories,
     addMemory,
     getTopTracks,
     searchSpotifyTracks

--- a/utils/fetcher.js
+++ b/utils/fetcher.js
@@ -12,6 +12,14 @@ const getMemories = async (token) => {
     return response.data
 }
 
+const searchSpotifyTracks = async (search, limit, token) => {
+    const config = {
+        headers: { Authorization: `Bearer ${token}` }
+    };
+    const response = await axios.get(`/api/search-spotify-tracks?search=${search}&limit=${limit}`, config)
+    return response.data
+}
+
 const addMemory = async (memory, token) => {
     const config = {
         headers: { Authorization: `Bearer ${token}` }
@@ -34,5 +42,6 @@ export {
     fetcher, 
     getMemories, 
     addMemory,
-    getTopTracks 
+    getTopTracks,
+    searchSpotifyTracks
 }


### PR DESCRIPTION
This adds an endpoint to search spotify for a track, and populates a table on the memory page with the results as the user types.

Long term I'd like the search box to have autocomplete based on the search, with the option to select one of the autocomplete suggestions. This resolves ambiguity in the data model, so we will have the "track" part of a memory in a canonical format.

maybe we could use [react-bootstrap-typeahead](https://www.npmjs.com/package/react-bootstrap-typeahead)?